### PR TITLE
docs(technical-writing): README에 project-contributing-structure 스킬 추가 및 사용 예시 개선

### DIFF
--- a/plugins/technical-writing/README.md
+++ b/plugins/technical-writing/README.md
@@ -13,6 +13,7 @@ graph LR
 
     D --> D1[project-readme-structure<br/>프로젝트 루트 README 규약]
     D --> D2[plugin-readme-structure<br/>플러그인 README 규약]
+    D --> D3[project-contributing-structure<br/>프로젝트 CONTRIBUTING 규약]
 ```
 
 ## 💾 설치 방법
@@ -43,21 +44,7 @@ graph LR
 
 ### 📖 Skills
 
-Skills는 `/technical-writing:<skill-name>` 형태로 호출합니다.
-
-#### plugin-readme-structure
-
-##### with plugin namespace
-
-```
-/technical-writing:plugin-readme-structure
-```
-
-##### without plugin namespace
-
-```
-/plugin-readme-structure
-```
+이 플러그인의 모든 스킬은 `user-invocable: false`로 설정된 지침형 스킬입니다. 직접 호출하지 않아도 에이전트가 관련 문서를 작성할 때 자동으로 참조합니다.
 
 ### 🤖 Agents
 
@@ -85,6 +72,7 @@ README 파일을 작성해 줘
 |------|------|------|
 | project-readme-structure | 지침형 | 마켓플레이스 프로젝트 루트 README.md의 필수 섹션, 다이어그램 작성 방식, 언어 규칙 등 작성 규약을 정의합니다. |
 | plugin-readme-structure | 지침형 | 개별 플러그인 README.md의 필수 섹션, 설치 명령어 형식, 기능 목록 작성 형식 등 작성 규약을 정의합니다. |
+| project-contributing-structure | 지침형 | 프로젝트 CONTRIBUTING.md의 필수 섹션, 개발 환경 구성, 기여 절차 등 작성 규약을 정의합니다. |
 
 ### 🤖 Agents
 


### PR DESCRIPTION
## Summary

- `project-analyzer` 플러그인이 자동 분석하여 발견한 README 문서 불일치 3건을 수정합니다.
- `user-invocable: false`인 스킬에 잘못 표기된 직접 호출 예시를 지침형 스킬에 적합한 안내 문구로 교체합니다.
- Mermaid 다이어그램과 Skills 테이블에 누락된 `project-contributing-structure` 스킬을 추가합니다.

## Related Issue

Closes #7

## Change Type

- [x] `docs` — 문서 변경 (코드 변경 없음)

## Affected Plugin(s)

- [x] `technical-writing`

## Changes Made

- `plugins/technical-writing/README.md` Mermaid 다이어그램에 `project-contributing-structure` 스킬 노드 추가
- Skills 사용 예시 섹션에서 `plugin-readme-structure` 스킬의 직접 호출 예시(`/technical-writing:plugin-readme-structure`)를 지침형 스킬 안내 문구로 교체
- Skills 테이블에 `project-contributing-structure` 스킬 행 추가

## Testing

- [x] Plugin installs successfully via `/plugin install`
- [x] Skills appear in `/skills` and work as expected
- [x] Agents appear in `/agents` and work as expected
- [ ] Hooks execute correctly on their configured events
- [x] Verified after restarting Claude Code session

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] `plugin.json` version is updated (if plugin changed)
- [ ] `marketplace.json` is updated (if plugin added or metadata changed)
- [x] Documentation is updated (README, SKILL.md, etc.)
- [x] I have read the [CONTRIBUTING.md](https://github.com/iamhoonse-dev/hoonse-claude-plugins/blob/main/CONTRIBUTING.md)

## Reviewer Notes

이 PR은 `project-analyzer` 플러그인이 자동 생성한 이슈(#7)를 기반으로 작성되었습니다. 코드 변경 없이 README 문서만 수정합니다.