### PR TITLE
docs(git-workflow): README 사용 예시 섹션의 Skills/Agents 배치 순서 수정

### DIFF
--- a/plugins/git-workflow/README.md
+++ b/plugins/git-workflow/README.md
@@ -42,6 +42,26 @@ graph LR
 
 ## 🧑‍💻 사용 예시
 
+### 📖 Skills
+
+Skills는 `/git-workflow:<skill-name>` 형태로 호출합니다.
+
+#### commit-message
+
+`commit-message` 스킬은 `user-invocable: false`로 설정된 지침형 스킬입니다. Claude가 커밋 메시지를 작성할 때 자동으로 참조하며, 직접 호출하지 않아도 됩니다.
+
+##### with plugin namespace
+
+```
+/git-workflow:commit-message
+```
+
+##### without plugin namespace
+
+```
+/commit-message
+```
+
 ### 🤖 Agents
 
 Agents는 대화 중 관련 요청 시 자동으로 활성화되거나, 직접 요청할 수 있습니다.
@@ -72,26 +92,6 @@ Agents는 대화 중 관련 요청 시 자동으로 활성화되거나, 직접 �
 
 ```
 브랜치 만들어줘
-```
-
-### 📖 Skills
-
-Skills는 `/git-workflow:<skill-name>` 형태로 호출합니다.
-
-#### commit-message
-
-`commit-message` 스킬은 `user-invocable: false`로 설정된 지침형 스킬입니다. Claude가 커밋 메시지를 작성할 때 자동으로 참조하며, 직접 호출하지 않아도 됩니다.
-
-##### with plugin namespace
-
-```
-/git-workflow:commit-message
-```
-
-##### without plugin namespace
-
-```
-/commit-message
 ```
 
 ## 🛠️ 기능


### PR DESCRIPTION
## Summary

- `plugin-readme-structure` 규약에 따라 사용 예시 섹션의 배치 순서를 Skills → Agents 순서로 통일
- 기존에 Agents 예시가 Skills 예시보다 앞에 위치하여 규약과 불일치하는 문제를 해소

## Related Issue

Closes #8

## Change Type

- [x] `docs` — 코드 변경 없이 문서만 수정

## Affected Plugin(s)

- [x] `git-workflow`

## Changes Made

- `plugins/git-workflow/README.md` 사용 예시 섹션에서 Agents 예시와 Skills 예시의 순서를 변경 (Agents → Skills → Agents 순서로 재배치)

## Testing

- [ ] Plugin installs successfully via `/plugin install`
- [ ] Skills appear in `/skills` and work as expected
- [ ] Agents appear in `/agents` and work as expected
- [ ] Hooks execute correctly on their configured events
- [ ] Verified after restarting Claude Code session

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] `plugin.json` version is updated (if plugin changed)
- [ ] `marketplace.json` is updated (if plugin added or metadata changed)
- [x] Documentation is updated (README, SKILL.md, etc.)
- [ ] I have read the [CONTRIBUTING.md](https://github.com/iamhoonse-dev/hoonse-claude-plugins/blob/main/CONTRIBUTING.md)

## Reviewer Notes

문서 구조 규약(plugin-readme-structure)과의 일관성을 위한 순서 조정으로, 실제 동작에는 영향 없음