### PR TITLE
feat(github-workflow): PR 생성 시 type/scope 기반 라벨 자동 부착 기능 추가

### DIFF
--- a/plugins/github-workflow/agents/pr-creator.md
+++ b/plugins/github-workflow/agents/pr-creator.md
@@ -52,8 +52,19 @@ Based on the analysis, determine:
 1. **scope**: The affected plugin or area — infer from changed file paths.
 1. **description**: A concise summary in Korean, noun form, 72 characters max.
 1. **Affected plugins**: List of plugins modified in this branch.
+1. **labels**: Determine candidate labels based on pr-convention rules:
+   - **type label**: `feat`→`enhancement`, `fix`→`bug`, `docs`→`documentation` (others have no mapping)
+   - **scope label**: If scope is a plugin name, use `plugin:<scope>` (e.g., `plugin:github-workflow`)
 
-### Step 6: Craft PR Title and Body
+### Step 6: Validate Labels
+
+For each candidate label determined in Step 5:
+
+1. Run `gh label list --search "<label>" --json name` to check if the label exists in the repository.
+1. Only add labels that exist to the confirmed labels list.
+1. If a label does not exist, skip it silently (do not create labels or fail).
+
+### Step 7: Craft PR Title and Body
 
 Following the pr-convention skill:
 
@@ -67,14 +78,18 @@ Following the pr-convention skill:
    - Testing: Include relevant testing checklist items
    - Checklist: Check applicable items
    - Reviewer Notes: Add if there are notable points
+1. **Labels**: Prepare `--label` flags for each confirmed label from Step 6.
 
-### Step 7: Create the PR
+### Step 8: Create the PR
 
 Execute `gh pr create` with the HEREDOC format specified in the pr-convention skill. Target `main` as the base branch.
 
+- If confirmed labels exist, include `--label` flags in the command.
+- If no confirmed labels, create the PR without `--label` flags.
+
 After the PR is created, capture and report the PR URL.
 
-### Step 8: Report the Result
+### Step 9: Report the Result
 
 Provide a summary:
 
@@ -83,6 +98,7 @@ Provide a summary:
 - The base branch (`main`)
 - Number of commits included
 - Files changed summary
+- Applied labels (if any)
 
 ## Important Rules
 
@@ -101,6 +117,7 @@ Provide a summary:
 - If no commits ahead of main: inform the user there's nothing to create a PR for.
 - If a PR already exists for this branch: inform the user and provide the existing PR URL.
 - If `gh pr create` fails: report the exact error message.
+- If `gh pr create` fails due to labels: retry without `--label` flags and report the label issue.
 
 ## Output Format
 

--- a/plugins/github-workflow/skills/pr-convention/SKILL.md
+++ b/plugins/github-workflow/skills/pr-convention/SKILL.md
@@ -34,6 +34,37 @@ Conventional Commits와 동일한 형식을 사용합니다:
 - 프로젝트 전역 변경: scope 생략 또는 대상 명시 (예: `docs(readme):`)
 - 마켓플레이스 설정 변경: `marketplace`를 scope로 사용
 
+### PR 라벨 규칙
+
+PR 생성 시 type과 scope에 기반하여 라벨을 자동으로 부착합니다.
+
+#### type → 라벨 매핑
+
+| type | 라벨 | 비고 |
+|------|------|------|
+| `feat` | `enhancement` | 새 기능 |
+| `fix` | `bug` | 버그 수정 |
+| `docs` | `documentation` | 문서 변경 |
+| 그 외 | — | 대응 라벨 없음 |
+
+#### scope → 플러그인 라벨 매핑
+
+| scope | 라벨 | 비고 |
+|-------|------|------|
+| 플러그인 이름 | `plugin:<scope>` | 예: `plugin:github-workflow` |
+| 그 외 | — | 대응 라벨 없음 |
+
+#### 라벨 존재 확인
+
+라벨을 부착하기 전에 반드시 프로젝트에 해당 라벨이 존재하는지 확인합니다:
+
+```bash
+gh label list --search "<label>" --json name
+```
+
+- 존재하는 라벨만 `--label` 플래그로 추가합니다.
+- 존재하지 않는 라벨은 무시합니다 (라벨 없이 PR 생성).
+
 ### PR 본문 구조
 
 PR 본문은 다음 섹션을 순서대로 포함합니다:
@@ -130,6 +161,17 @@ EOF
 )"
 ```
 
+#### 라벨 포함 (라벨이 존재하는 경우)
+
+```bash
+gh pr create --title "<type>[(scope)]: <description>" \
+  --label "<type-label>" --label "<scope-label>" \
+  --body "$(cat <<'EOF'
+...
+EOF
+)"
+```
+
 ### 예시
 
 ```
@@ -139,3 +181,13 @@ feat(github-workflow): GitHub Issue 기반 개발 워크플로우 플러그인 �
 ```
 fix(git-workflow): auto-committer에서 스테이징되지 않은 파일 처리 오류 수정
 ```
+
+### 라벨 결정 예시
+
+| PR 제목 | type 라벨 | scope 라벨 |
+|---------|-----------|------------|
+| `feat(github-workflow): PR 라벨 자동 부착 기능 추가` | `enhancement` | `plugin:github-workflow` |
+| `fix(git-workflow): auto-committer 오류 수정` | `bug` | `plugin:git-workflow` |
+| `docs(readme): 프로젝트 README 업데이트` | `documentation` | — |
+| `refactor(github-workflow): 코드 구조 개선` | — | `plugin:github-workflow` |
+| `chore: 의존성 업데이트` | — | — |


### PR DESCRIPTION
## Summary

- pr-creator 에이전트가 PR 생성 시 type과 scope를 분석하여 라벨을 자동으로 부착하도록 워크플로우를 개선함
- 존재하지 않는 라벨은 무시하고 존재하는 라벨만 선택적으로 부착하여 안정성을 확보함

## Related Issue

이슈 없음

## Change Type

- [x] `feat` — 새로운 기능 추가

## Affected Plugin(s)

- [x] `github-workflow`

## Changes Made

- `plugins/github-workflow/agents/pr-creator.md`: PR 생성 워크플로우에 라벨 결정(Step 5), 라벨 유효성 검사(Step 6), 라벨 적용(Step 8) 단계 추가
- `plugins/github-workflow/skills/pr-convention/SKILL.md`: type→라벨 매핑 규칙, scope→플러그인 라벨 매핑 규칙, 라벨 존재 확인 방법, 라벨 포함 `gh pr create` 명령 형식 및 예시 추가

## Testing

- [ ] Plugin installs successfully via `/plugin install`
- [ ] Skills appear in `/skills` and work as expected
- [ ] Agents appear in `/agents` and work as expected
- [ ] Hooks execute correctly on their configured events
- [ ] Verified after restarting Claude Code session

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] `plugin.json` version is updated (if plugin changed)
- [ ] `marketplace.json` is updated (if plugin added or metadata changed)
- [x] Documentation is updated (README, SKILL.md, etc.)
- [ ] I have read the [CONTRIBUTING.md](https://github.com/iamhoonse-dev/hoonse-claude-plugins/blob/main/CONTRIBUTING.md)

## Reviewer Notes

- `plugin:github-workflow` 라벨이 저장소에 존재하지 않아 `enhancement` 라벨만 부착하였습니다.
- 향후 `plugin:github-workflow` 라벨이 생성되면 자동으로 부착됩니다.